### PR TITLE
docker-bake.sh: use SSH_AUTH_SOCK instead of mounting ~/.ssh

### DIFF
--- a/docker-bake.sh
+++ b/docker-bake.sh
@@ -2,7 +2,7 @@
 
 docker run --rm -it \
 -v $(pwd):$(pwd) \
--v ~/.ssh:/home/build/.ssh \
+-v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK  \
 -v ~/.gitconfig:/home/build/.gitconfig \
 3mdeb/yocto-docker \
 /bin/bash -c "cd $(pwd) && source oe-init-build-env && bitbake $*"


### PR DESCRIPTION
@macpijan  please check if this is good enough on your setup and if this works please merge this change.

BTW you may need to run `ssh-agent` before, if this is needed add required command to script.