### PR TITLE
Dockerfile: add libssl-dev - openssl/bio.h missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get clean && apt-get update && apt-get install -y \
     cpio \
     gcc \
     g++ \
-    python3
+    python3 \
+    libssl-dev
 
 RUN useradd -ms /bin/bash build && \
     usermod -aG sudo build


### PR DESCRIPTION
It fixes `fatal error: openssl/bio.h: No such file or directory #include <openssl/bio.h>` during kernel compilation