### PR TITLE
Dockerfile: locale configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,24 @@
 FROM debian:jessie
 MAINTAINER Piotr Król <piotr.krol@3mdeb.com>
 
-RUN apt-get clean && apt-get update && apt-get install -y \
+# Update the package repository
+RUN apt-get update && apt-get upgrade -y && apt-get install locales
+
+# Configure locales
+# noninteractive installation using debconf-set-selections does not seem
+# to work due to a bug in Debian glibc:
+# https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1598326
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# Yocto dependencies
+RUN apt-get install -y \
     gawk \
     wget \
     git-core \


### PR DESCRIPTION
Fixes following message while starting a build with poky at `morty` revision:

```
Please use a locale setting which supports utf-8.
Python can't change the filesystem locale after loading so we need a utf-8 when python starts or things won't work
```