### PR TITLE
docker-bake.sh: set StrictHostKeyCheck=no during ssh session

### DIFF
--- a/docker-bake.sh
+++ b/docker-bake.sh
@@ -5,4 +5,5 @@ docker run --rm -it \
 -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK  \
 -v ~/.gitconfig:/home/build/.gitconfig \
 3mdeb/yocto-docker \
-/bin/bash -c "ssh -T git@github.com; cd $(pwd) && source oe-init-build-env && bitbake $*"
+/bin/bash -c "ssh -T -o StrictHostKeyChecking=no git@github.com; \
+              cd $(pwd) && source oe-init-build-env && bitbake $*"


### PR DESCRIPTION
Allow for non-interactive automated builds - user doesn't have to type yes to accept fingerprint