### PR TITLE
Dockerfile: add python2.7 and python2/3 devel packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get install -y \
     python3 \
     python3-pip \
     python3-pexpect \
+    python-dev \
+    python3-dev \
     xz-utils \
     debianutils \
     iputils-ping \


### PR DESCRIPTION
Recipe for u-boot in RTE Yocto image fails because of lack
of Python C headers. Installing python3-dev package is not sufficient.
After installing python devel packages, u-boot recipe finishes
with success. It did the trick for me.

Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>