### PR TITLE
Dockerfile: add latest Yocto build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,15 @@ RUN apt-get install -y \
     cpio \
     gcc \
     g++ \
+    python \
     python3 \
+    python3-pip \
+    python3-pexpect \
+    xz-utils \
+    debianutils \
+    iputils-ping \
+    libsdl1.2-dev \
+    xterm \
     libssl-dev
 
 RUN useradd -ms /bin/bash build && \


### PR DESCRIPTION
Add latest build dependencies based on
the paragraph: 1.2.1.2.2. The Build Host Packages
of the Yocto Project manual:
https://www.yoctoproject.org/docs/latest/yocto-project-qs/yocto-project-qs.html

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>