### PR TITLE
Dockerfile: switch to Ubuntu:16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:jessie
+FROM ubuntu:16.04
+
 MAINTAINER Piotr Król <piotr.krol@3mdeb.com>
 
 # Update the package repository


### PR DESCRIPTION
Debian Jessie has already quite dated packages.
At least we need openjdk8 for Jenkins builds.
We could switch to more recent Debian as well but
it seems to me that Ubuntu is most widely used
for Yocto  builds.

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>